### PR TITLE
Return statement execution result as an object

### DIFF
--- a/src/main/java/org/senthilvsh/saffron/runtime/ReturnStatementResult.java
+++ b/src/main/java/org/senthilvsh/saffron/runtime/ReturnStatementResult.java
@@ -1,0 +1,14 @@
+package org.senthilvsh.saffron.runtime;
+
+public class ReturnStatementResult extends StatementResult {
+    private final BaseObj returnValue;
+
+    public ReturnStatementResult(BaseObj returnValue) {
+        super(StatementResultType.RETURN);
+        this.returnValue = returnValue;
+    }
+
+    public BaseObj getReturnValue() {
+        return returnValue;
+    }
+}

--- a/src/main/java/org/senthilvsh/saffron/runtime/StatementResult.java
+++ b/src/main/java/org/senthilvsh/saffron/runtime/StatementResult.java
@@ -1,0 +1,16 @@
+package org.senthilvsh.saffron.runtime;
+
+/**
+ * Represents the result of executing a statement.
+ */
+public class StatementResult {
+    private final StatementResultType type;
+
+    public StatementResult(StatementResultType type) {
+        this.type = type;
+    }
+
+    public StatementResultType getType() {
+        return type;
+    }
+}

--- a/src/main/java/org/senthilvsh/saffron/runtime/StatementResultType.java
+++ b/src/main/java/org/senthilvsh/saffron/runtime/StatementResultType.java
@@ -1,0 +1,9 @@
+package org.senthilvsh.saffron.runtime;
+
+public enum StatementResultType {
+    NORMAL, // Statement completed normally
+    RETURN, // Return statement was executed
+    BREAK, // Break statement was executed
+    CONTINUE, // Continue statement was executed
+    EXCEPTION // An exception was thrown by the statement
+}

--- a/src/main/java/org/senthilvsh/saffron/stdlib/NativeFunction.java
+++ b/src/main/java/org/senthilvsh/saffron/stdlib/NativeFunction.java
@@ -3,7 +3,7 @@ package org.senthilvsh.saffron.stdlib;
 import org.senthilvsh.saffron.ast.FunctionArgument;
 import org.senthilvsh.saffron.common.Frame;
 import org.senthilvsh.saffron.common.Type;
-import org.senthilvsh.saffron.runtime.FunctionReturn;
+import org.senthilvsh.saffron.runtime.StatementResult;
 
 import java.util.List;
 
@@ -14,5 +14,5 @@ public interface NativeFunction {
 
     Type getReturnType();
 
-    void run(Frame frame) throws FunctionReturn;
+    StatementResult run(Frame frame);
 }

--- a/src/main/java/org/senthilvsh/saffron/stdlib/console/ReadLine.java
+++ b/src/main/java/org/senthilvsh/saffron/stdlib/console/ReadLine.java
@@ -3,7 +3,8 @@ package org.senthilvsh.saffron.stdlib.console;
 import org.senthilvsh.saffron.ast.FunctionArgument;
 import org.senthilvsh.saffron.common.Frame;
 import org.senthilvsh.saffron.common.Type;
-import org.senthilvsh.saffron.runtime.FunctionReturn;
+import org.senthilvsh.saffron.runtime.ReturnStatementResult;
+import org.senthilvsh.saffron.runtime.StatementResult;
 import org.senthilvsh.saffron.runtime.StringObj;
 import org.senthilvsh.saffron.stdlib.NativeFunction;
 
@@ -28,7 +29,7 @@ public class ReadLine implements NativeFunction {
     }
 
     @Override
-    public void run(Frame frame) throws FunctionReturn {
-        throw new FunctionReturn(new StringObj(new Scanner(System.in).nextLine()));
+    public StatementResult run(Frame frame) {
+        return new ReturnStatementResult(new StringObj(new Scanner(System.in).nextLine()));
     }
 }

--- a/src/main/java/org/senthilvsh/saffron/stdlib/console/WriteBoolean.java
+++ b/src/main/java/org/senthilvsh/saffron/stdlib/console/WriteBoolean.java
@@ -4,7 +4,9 @@ import org.senthilvsh.saffron.ast.FunctionArgument;
 import org.senthilvsh.saffron.common.Frame;
 import org.senthilvsh.saffron.common.Type;
 import org.senthilvsh.saffron.runtime.BooleanObj;
-import org.senthilvsh.saffron.runtime.FunctionReturn;
+import org.senthilvsh.saffron.runtime.ReturnStatementResult;
+import org.senthilvsh.saffron.runtime.StatementResult;
+import org.senthilvsh.saffron.runtime.StatementResultType;
 import org.senthilvsh.saffron.stdlib.NativeFunction;
 
 import java.util.List;
@@ -26,8 +28,9 @@ public class WriteBoolean implements NativeFunction {
     }
 
     @Override
-    public void run(Frame frame) throws FunctionReturn {
+    public StatementResult run(Frame frame) {
         BooleanObj baseObj = (BooleanObj) frame.get("value").getValue();
         System.out.print(baseObj.getValue());
+        return new ReturnStatementResult(null);
     }
 }

--- a/src/main/java/org/senthilvsh/saffron/stdlib/console/WriteBooleanNL.java
+++ b/src/main/java/org/senthilvsh/saffron/stdlib/console/WriteBooleanNL.java
@@ -4,7 +4,9 @@ import org.senthilvsh.saffron.ast.FunctionArgument;
 import org.senthilvsh.saffron.common.Frame;
 import org.senthilvsh.saffron.common.Type;
 import org.senthilvsh.saffron.runtime.BooleanObj;
-import org.senthilvsh.saffron.runtime.FunctionReturn;
+import org.senthilvsh.saffron.runtime.ReturnStatementResult;
+import org.senthilvsh.saffron.runtime.StatementResult;
+import org.senthilvsh.saffron.runtime.StatementResultType;
 import org.senthilvsh.saffron.stdlib.NativeFunction;
 
 import java.util.List;
@@ -26,8 +28,9 @@ public class WriteBooleanNL implements NativeFunction {
     }
 
     @Override
-    public void run(Frame frame) throws FunctionReturn {
+    public StatementResult run(Frame frame) {
         BooleanObj baseObj = (BooleanObj) frame.get("value").getValue();
         System.out.println(baseObj.getValue());
+        return new ReturnStatementResult(null);
     }
 }

--- a/src/main/java/org/senthilvsh/saffron/stdlib/console/WriteNumber.java
+++ b/src/main/java/org/senthilvsh/saffron/stdlib/console/WriteNumber.java
@@ -3,8 +3,10 @@ package org.senthilvsh.saffron.stdlib.console;
 import org.senthilvsh.saffron.ast.FunctionArgument;
 import org.senthilvsh.saffron.common.Frame;
 import org.senthilvsh.saffron.common.Type;
-import org.senthilvsh.saffron.runtime.FunctionReturn;
 import org.senthilvsh.saffron.runtime.NumberObj;
+import org.senthilvsh.saffron.runtime.ReturnStatementResult;
+import org.senthilvsh.saffron.runtime.StatementResult;
+import org.senthilvsh.saffron.runtime.StatementResultType;
 import org.senthilvsh.saffron.stdlib.NativeFunction;
 
 import java.util.List;
@@ -26,7 +28,7 @@ public class WriteNumber implements NativeFunction {
     }
 
     @Override
-    public void run(Frame frame) throws FunctionReturn {
+    public StatementResult run(Frame frame) {
         NumberObj numberObj = (NumberObj) frame.get("value").getValue();
         double value = numberObj.getValue();
         String str;
@@ -36,5 +38,6 @@ public class WriteNumber implements NativeFunction {
             str = String.valueOf(value);
         }
         System.out.print(str);
+        return new ReturnStatementResult(null);
     }
 }

--- a/src/main/java/org/senthilvsh/saffron/stdlib/console/WriteNumberNL.java
+++ b/src/main/java/org/senthilvsh/saffron/stdlib/console/WriteNumberNL.java
@@ -3,8 +3,10 @@ package org.senthilvsh.saffron.stdlib.console;
 import org.senthilvsh.saffron.ast.FunctionArgument;
 import org.senthilvsh.saffron.common.Frame;
 import org.senthilvsh.saffron.common.Type;
-import org.senthilvsh.saffron.runtime.FunctionReturn;
 import org.senthilvsh.saffron.runtime.NumberObj;
+import org.senthilvsh.saffron.runtime.ReturnStatementResult;
+import org.senthilvsh.saffron.runtime.StatementResult;
+import org.senthilvsh.saffron.runtime.StatementResultType;
 import org.senthilvsh.saffron.stdlib.NativeFunction;
 
 import java.util.List;
@@ -26,7 +28,7 @@ public class WriteNumberNL implements NativeFunction {
     }
 
     @Override
-    public void run(Frame frame) throws FunctionReturn {
+    public StatementResult run(Frame frame) {
         NumberObj numberObj = (NumberObj) frame.get("value").getValue();
         double value = numberObj.getValue();
         String str;
@@ -36,5 +38,6 @@ public class WriteNumberNL implements NativeFunction {
             str = String.valueOf(value);
         }
         System.out.println(str);
+        return new ReturnStatementResult(null);
     }
 }

--- a/src/main/java/org/senthilvsh/saffron/stdlib/console/WriteString.java
+++ b/src/main/java/org/senthilvsh/saffron/stdlib/console/WriteString.java
@@ -3,7 +3,9 @@ package org.senthilvsh.saffron.stdlib.console;
 import org.senthilvsh.saffron.ast.FunctionArgument;
 import org.senthilvsh.saffron.common.Frame;
 import org.senthilvsh.saffron.common.Type;
-import org.senthilvsh.saffron.runtime.FunctionReturn;
+import org.senthilvsh.saffron.runtime.ReturnStatementResult;
+import org.senthilvsh.saffron.runtime.StatementResult;
+import org.senthilvsh.saffron.runtime.StatementResultType;
 import org.senthilvsh.saffron.runtime.StringObj;
 import org.senthilvsh.saffron.stdlib.NativeFunction;
 
@@ -26,8 +28,9 @@ public class WriteString implements NativeFunction {
     }
 
     @Override
-    public void run(Frame frame) throws FunctionReturn {
+    public StatementResult run(Frame frame) {
         StringObj baseObj = (StringObj) frame.get("value").getValue();
         System.out.print(baseObj.getValue());
+        return new ReturnStatementResult(null);
     }
 }

--- a/src/main/java/org/senthilvsh/saffron/stdlib/console/WriteStringNL.java
+++ b/src/main/java/org/senthilvsh/saffron/stdlib/console/WriteStringNL.java
@@ -3,7 +3,9 @@ package org.senthilvsh.saffron.stdlib.console;
 import org.senthilvsh.saffron.ast.FunctionArgument;
 import org.senthilvsh.saffron.common.Frame;
 import org.senthilvsh.saffron.common.Type;
-import org.senthilvsh.saffron.runtime.FunctionReturn;
+import org.senthilvsh.saffron.runtime.ReturnStatementResult;
+import org.senthilvsh.saffron.runtime.StatementResult;
+import org.senthilvsh.saffron.runtime.StatementResultType;
 import org.senthilvsh.saffron.runtime.StringObj;
 import org.senthilvsh.saffron.stdlib.NativeFunction;
 
@@ -26,8 +28,9 @@ public class WriteStringNL implements NativeFunction {
     }
 
     @Override
-    public void run(Frame frame) throws FunctionReturn {
+    public StatementResult run(Frame frame) {
         StringObj baseObj = (StringObj) frame.get("value").getValue();
         System.out.println(baseObj.getValue());
+        return new ReturnStatementResult(null);
     }
 }

--- a/src/main/java/org/senthilvsh/saffron/stdlib/conversion/BooleanToString.java
+++ b/src/main/java/org/senthilvsh/saffron/stdlib/conversion/BooleanToString.java
@@ -5,8 +5,8 @@ import org.senthilvsh.saffron.common.Frame;
 import org.senthilvsh.saffron.common.Type;
 import org.senthilvsh.saffron.common.Variable;
 import org.senthilvsh.saffron.runtime.BooleanObj;
-import org.senthilvsh.saffron.runtime.FunctionReturn;
-import org.senthilvsh.saffron.runtime.NumberObj;
+import org.senthilvsh.saffron.runtime.ReturnStatementResult;
+import org.senthilvsh.saffron.runtime.StatementResult;
 import org.senthilvsh.saffron.runtime.StringObj;
 import org.senthilvsh.saffron.stdlib.NativeFunction;
 
@@ -31,7 +31,7 @@ public class BooleanToString implements NativeFunction {
     }
 
     @Override
-    public void run(Frame frame) throws FunctionReturn {
+    public StatementResult run(Frame frame) {
         Variable sourceVar = frame.get("source");
         BooleanObj sourceObj = (BooleanObj) sourceVar.getValue();
         boolean source = sourceObj.getValue();
@@ -40,6 +40,6 @@ public class BooleanToString implements NativeFunction {
 
         StringObj returnObj = new StringObj(result);
 
-        throw new FunctionReturn(returnObj);
+        return new ReturnStatementResult(returnObj);
     }
 }

--- a/src/main/java/org/senthilvsh/saffron/stdlib/conversion/NumberToString.java
+++ b/src/main/java/org/senthilvsh/saffron/stdlib/conversion/NumberToString.java
@@ -4,9 +4,9 @@ import org.senthilvsh.saffron.ast.FunctionArgument;
 import org.senthilvsh.saffron.common.Frame;
 import org.senthilvsh.saffron.common.Type;
 import org.senthilvsh.saffron.common.Variable;
-import org.senthilvsh.saffron.runtime.BooleanObj;
-import org.senthilvsh.saffron.runtime.FunctionReturn;
 import org.senthilvsh.saffron.runtime.NumberObj;
+import org.senthilvsh.saffron.runtime.ReturnStatementResult;
+import org.senthilvsh.saffron.runtime.StatementResult;
 import org.senthilvsh.saffron.runtime.StringObj;
 import org.senthilvsh.saffron.stdlib.NativeFunction;
 
@@ -31,7 +31,7 @@ public class NumberToString implements NativeFunction {
     }
 
     @Override
-    public void run(Frame frame) throws FunctionReturn {
+    public StatementResult run(Frame frame) {
         Variable sourceVar = frame.get("source");
         NumberObj sourceObj = (NumberObj) sourceVar.getValue();
         double source = sourceObj.getValue();
@@ -45,6 +45,6 @@ public class NumberToString implements NativeFunction {
 
         StringObj returnObj = new StringObj(result);
 
-        throw new FunctionReturn(returnObj);
+        return new ReturnStatementResult(returnObj);
     }
 }

--- a/src/main/java/org/senthilvsh/saffron/stdlib/conversion/StringToBoolean.java
+++ b/src/main/java/org/senthilvsh/saffron/stdlib/conversion/StringToBoolean.java
@@ -5,8 +5,8 @@ import org.senthilvsh.saffron.common.Frame;
 import org.senthilvsh.saffron.common.Type;
 import org.senthilvsh.saffron.common.Variable;
 import org.senthilvsh.saffron.runtime.BooleanObj;
-import org.senthilvsh.saffron.runtime.FunctionReturn;
-import org.senthilvsh.saffron.runtime.NumberObj;
+import org.senthilvsh.saffron.runtime.ReturnStatementResult;
+import org.senthilvsh.saffron.runtime.StatementResult;
 import org.senthilvsh.saffron.runtime.StringObj;
 import org.senthilvsh.saffron.stdlib.NativeFunction;
 
@@ -31,7 +31,7 @@ public class StringToBoolean implements NativeFunction {
     }
 
     @Override
-    public void run(Frame frame) throws FunctionReturn {
+    public StatementResult run(Frame frame) {
         Variable sourceVar = frame.get("source");
         StringObj sourceObj = (StringObj) sourceVar.getValue();
         String source = sourceObj.getValue();
@@ -48,6 +48,6 @@ public class StringToBoolean implements NativeFunction {
 
         BooleanObj returnObj = new BooleanObj(result);
 
-        throw new FunctionReturn(returnObj);
+        return new ReturnStatementResult(returnObj);
     }
 }

--- a/src/main/java/org/senthilvsh/saffron/stdlib/conversion/StringToNumber.java
+++ b/src/main/java/org/senthilvsh/saffron/stdlib/conversion/StringToNumber.java
@@ -4,8 +4,9 @@ import org.senthilvsh.saffron.ast.FunctionArgument;
 import org.senthilvsh.saffron.common.Frame;
 import org.senthilvsh.saffron.common.Type;
 import org.senthilvsh.saffron.common.Variable;
-import org.senthilvsh.saffron.runtime.FunctionReturn;
 import org.senthilvsh.saffron.runtime.NumberObj;
+import org.senthilvsh.saffron.runtime.ReturnStatementResult;
+import org.senthilvsh.saffron.runtime.StatementResult;
 import org.senthilvsh.saffron.runtime.StringObj;
 import org.senthilvsh.saffron.stdlib.NativeFunction;
 
@@ -30,7 +31,7 @@ public class StringToNumber implements NativeFunction {
     }
 
     @Override
-    public void run(Frame frame) throws FunctionReturn {
+    public StatementResult run(Frame frame) {
         Variable sourceVar = frame.get("source");
         StringObj sourceObj = (StringObj) sourceVar.getValue();
         String source = sourceObj.getValue();
@@ -39,6 +40,6 @@ public class StringToNumber implements NativeFunction {
 
         NumberObj returnObj = new NumberObj(result);
 
-        throw new FunctionReturn(returnObj);
+        return new ReturnStatementResult(returnObj);
     }
 }

--- a/src/main/java/org/senthilvsh/saffron/stdlib/string/StringContains.java
+++ b/src/main/java/org/senthilvsh/saffron/stdlib/string/StringContains.java
@@ -5,8 +5,8 @@ import org.senthilvsh.saffron.common.Frame;
 import org.senthilvsh.saffron.common.Type;
 import org.senthilvsh.saffron.common.Variable;
 import org.senthilvsh.saffron.runtime.BooleanObj;
-import org.senthilvsh.saffron.runtime.FunctionReturn;
-import org.senthilvsh.saffron.runtime.NumberObj;
+import org.senthilvsh.saffron.runtime.ReturnStatementResult;
+import org.senthilvsh.saffron.runtime.StatementResult;
 import org.senthilvsh.saffron.runtime.StringObj;
 import org.senthilvsh.saffron.stdlib.NativeFunction;
 
@@ -32,7 +32,7 @@ public class StringContains implements NativeFunction {
     }
 
     @Override
-    public void run(Frame frame) throws FunctionReturn {
+    public StatementResult run(Frame frame) {
         Variable sourceVar = frame.get("source");
         StringObj sourceObj = (StringObj) sourceVar.getValue();
         String source = sourceObj.getValue();
@@ -45,6 +45,6 @@ public class StringContains implements NativeFunction {
 
         BooleanObj returnObj = new BooleanObj(result);
 
-        throw new FunctionReturn(returnObj);
+        return new ReturnStatementResult(returnObj);
     }
 }

--- a/src/main/java/org/senthilvsh/saffron/stdlib/string/StringEndsWith.java
+++ b/src/main/java/org/senthilvsh/saffron/stdlib/string/StringEndsWith.java
@@ -5,7 +5,8 @@ import org.senthilvsh.saffron.common.Frame;
 import org.senthilvsh.saffron.common.Type;
 import org.senthilvsh.saffron.common.Variable;
 import org.senthilvsh.saffron.runtime.BooleanObj;
-import org.senthilvsh.saffron.runtime.FunctionReturn;
+import org.senthilvsh.saffron.runtime.ReturnStatementResult;
+import org.senthilvsh.saffron.runtime.StatementResult;
 import org.senthilvsh.saffron.runtime.StringObj;
 import org.senthilvsh.saffron.stdlib.NativeFunction;
 
@@ -31,7 +32,7 @@ public class StringEndsWith implements NativeFunction {
     }
 
     @Override
-    public void run(Frame frame) throws FunctionReturn {
+    public StatementResult run(Frame frame) {
         Variable sourceVar = frame.get("source");
         StringObj sourceObj = (StringObj) sourceVar.getValue();
         String source = sourceObj.getValue();
@@ -44,6 +45,6 @@ public class StringEndsWith implements NativeFunction {
 
         BooleanObj returnObj = new BooleanObj(result);
 
-        throw new FunctionReturn(returnObj);
+        return new ReturnStatementResult(returnObj);
     }
 }

--- a/src/main/java/org/senthilvsh/saffron/stdlib/string/StringLength.java
+++ b/src/main/java/org/senthilvsh/saffron/stdlib/string/StringLength.java
@@ -4,8 +4,9 @@ import org.senthilvsh.saffron.ast.FunctionArgument;
 import org.senthilvsh.saffron.common.Frame;
 import org.senthilvsh.saffron.common.Type;
 import org.senthilvsh.saffron.common.Variable;
-import org.senthilvsh.saffron.runtime.FunctionReturn;
 import org.senthilvsh.saffron.runtime.NumberObj;
+import org.senthilvsh.saffron.runtime.ReturnStatementResult;
+import org.senthilvsh.saffron.runtime.StatementResult;
 import org.senthilvsh.saffron.runtime.StringObj;
 import org.senthilvsh.saffron.stdlib.NativeFunction;
 
@@ -28,10 +29,15 @@ public class StringLength implements NativeFunction {
     }
 
     @Override
-    public void run(Frame frame) throws FunctionReturn {
+    public StatementResult run(Frame frame) {
         Variable variable = frame.get("source");
         StringObj stringObj = (StringObj) variable.getValue();
         String source = stringObj.getValue();
-        throw new FunctionReturn(new NumberObj(source.length()));
+
+        int result = source.length();
+
+        NumberObj returnObj = new NumberObj(result);
+
+        return new ReturnStatementResult(returnObj);
     }
 }

--- a/src/main/java/org/senthilvsh/saffron/stdlib/string/StringReplace.java
+++ b/src/main/java/org/senthilvsh/saffron/stdlib/string/StringReplace.java
@@ -4,8 +4,8 @@ import org.senthilvsh.saffron.ast.FunctionArgument;
 import org.senthilvsh.saffron.common.Frame;
 import org.senthilvsh.saffron.common.Type;
 import org.senthilvsh.saffron.common.Variable;
-import org.senthilvsh.saffron.runtime.BooleanObj;
-import org.senthilvsh.saffron.runtime.FunctionReturn;
+import org.senthilvsh.saffron.runtime.ReturnStatementResult;
+import org.senthilvsh.saffron.runtime.StatementResult;
 import org.senthilvsh.saffron.runtime.StringObj;
 import org.senthilvsh.saffron.stdlib.NativeFunction;
 
@@ -32,7 +32,7 @@ public class StringReplace implements NativeFunction {
     }
 
     @Override
-    public void run(Frame frame) throws FunctionReturn {
+    public StatementResult run(Frame frame) {
         Variable sourceVar = frame.get("source");
         StringObj sourceObj = (StringObj) sourceVar.getValue();
         String source = sourceObj.getValue();
@@ -49,6 +49,6 @@ public class StringReplace implements NativeFunction {
 
         StringObj returnObj = new StringObj(result);
 
-        throw new FunctionReturn(returnObj);
+        return new ReturnStatementResult(returnObj);
     }
 }

--- a/src/main/java/org/senthilvsh/saffron/stdlib/string/StringStartsWith.java
+++ b/src/main/java/org/senthilvsh/saffron/stdlib/string/StringStartsWith.java
@@ -5,7 +5,8 @@ import org.senthilvsh.saffron.common.Frame;
 import org.senthilvsh.saffron.common.Type;
 import org.senthilvsh.saffron.common.Variable;
 import org.senthilvsh.saffron.runtime.BooleanObj;
-import org.senthilvsh.saffron.runtime.FunctionReturn;
+import org.senthilvsh.saffron.runtime.ReturnStatementResult;
+import org.senthilvsh.saffron.runtime.StatementResult;
 import org.senthilvsh.saffron.runtime.StringObj;
 import org.senthilvsh.saffron.stdlib.NativeFunction;
 
@@ -31,7 +32,7 @@ public class StringStartsWith implements NativeFunction {
     }
 
     @Override
-    public void run(Frame frame) throws FunctionReturn {
+    public StatementResult run(Frame frame) {
         Variable sourceVar = frame.get("source");
         StringObj sourceObj = (StringObj) sourceVar.getValue();
         String source = sourceObj.getValue();
@@ -44,6 +45,6 @@ public class StringStartsWith implements NativeFunction {
 
         BooleanObj returnObj = new BooleanObj(result);
 
-        throw new FunctionReturn(returnObj);
+        return new ReturnStatementResult(returnObj);
     }
 }

--- a/src/main/java/org/senthilvsh/saffron/stdlib/string/StringSubString.java
+++ b/src/main/java/org/senthilvsh/saffron/stdlib/string/StringSubString.java
@@ -4,8 +4,9 @@ import org.senthilvsh.saffron.ast.FunctionArgument;
 import org.senthilvsh.saffron.common.Frame;
 import org.senthilvsh.saffron.common.Type;
 import org.senthilvsh.saffron.common.Variable;
-import org.senthilvsh.saffron.runtime.FunctionReturn;
 import org.senthilvsh.saffron.runtime.NumberObj;
+import org.senthilvsh.saffron.runtime.ReturnStatementResult;
+import org.senthilvsh.saffron.runtime.StatementResult;
 import org.senthilvsh.saffron.runtime.StringObj;
 import org.senthilvsh.saffron.stdlib.NativeFunction;
 
@@ -32,7 +33,7 @@ public class StringSubString implements NativeFunction {
     }
 
     @Override
-    public void run(Frame frame) throws FunctionReturn {
+    public StatementResult run(Frame frame) {
         Variable sourceVar = frame.get("source");
         StringObj sourceObj = (StringObj) sourceVar.getValue();
         String source = sourceObj.getValue();
@@ -49,6 +50,6 @@ public class StringSubString implements NativeFunction {
 
         StringObj returnObj = new StringObj(result);
 
-        throw new FunctionReturn(returnObj);
+        return new ReturnStatementResult(returnObj);
     }
 }

--- a/src/main/java/org/senthilvsh/saffron/stdlib/string/StringSubStringToEnd.java
+++ b/src/main/java/org/senthilvsh/saffron/stdlib/string/StringSubStringToEnd.java
@@ -4,8 +4,9 @@ import org.senthilvsh.saffron.ast.FunctionArgument;
 import org.senthilvsh.saffron.common.Frame;
 import org.senthilvsh.saffron.common.Type;
 import org.senthilvsh.saffron.common.Variable;
-import org.senthilvsh.saffron.runtime.FunctionReturn;
 import org.senthilvsh.saffron.runtime.NumberObj;
+import org.senthilvsh.saffron.runtime.ReturnStatementResult;
+import org.senthilvsh.saffron.runtime.StatementResult;
 import org.senthilvsh.saffron.runtime.StringObj;
 import org.senthilvsh.saffron.stdlib.NativeFunction;
 
@@ -31,7 +32,7 @@ public class StringSubStringToEnd implements NativeFunction {
     }
 
     @Override
-    public void run(Frame frame) throws FunctionReturn {
+    public StatementResult run(Frame frame) {
         Variable sourceVar = frame.get("source");
         StringObj sourceObj = (StringObj) sourceVar.getValue();
         String source = sourceObj.getValue();
@@ -44,6 +45,6 @@ public class StringSubStringToEnd implements NativeFunction {
 
         StringObj returnObj = new StringObj(result);
 
-        throw new FunctionReturn(returnObj);
+        return new ReturnStatementResult(returnObj);
     }
 }

--- a/src/main/java/org/senthilvsh/saffron/stdlib/string/StringTrim.java
+++ b/src/main/java/org/senthilvsh/saffron/stdlib/string/StringTrim.java
@@ -4,7 +4,8 @@ import org.senthilvsh.saffron.ast.FunctionArgument;
 import org.senthilvsh.saffron.common.Frame;
 import org.senthilvsh.saffron.common.Type;
 import org.senthilvsh.saffron.common.Variable;
-import org.senthilvsh.saffron.runtime.FunctionReturn;
+import org.senthilvsh.saffron.runtime.ReturnStatementResult;
+import org.senthilvsh.saffron.runtime.StatementResult;
 import org.senthilvsh.saffron.runtime.StringObj;
 import org.senthilvsh.saffron.stdlib.NativeFunction;
 
@@ -29,7 +30,7 @@ public class StringTrim implements NativeFunction {
     }
 
     @Override
-    public void run(Frame frame) throws FunctionReturn {
+    public StatementResult run(Frame frame) {
         Variable sourceVar = frame.get("source");
         StringObj sourceObj = (StringObj) sourceVar.getValue();
         String source = sourceObj.getValue();
@@ -38,6 +39,6 @@ public class StringTrim implements NativeFunction {
 
         StringObj returnObj = new StringObj(result);
 
-        throw new FunctionReturn(returnObj);
+        return new ReturnStatementResult(returnObj);
     }
 }


### PR DESCRIPTION
Previously flow-control statements like continue, break and return threw exceptions which will be caught and processed by upstream code. This is very ugly!

Now, such statements will return an instance of StatementResult or its sub-classes which can be handled cleanly by upstream code.

Regular statements will return an instance of this class with a NORMAL status which will mostly be ignored.