### PR TITLE
Implement block-level scope

### DIFF
--- a/src/main/java/org/senthilvsh/saffron/Main.java
+++ b/src/main/java/org/senthilvsh/saffron/Main.java
@@ -16,7 +16,6 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 
-// TODO: Use statement execution result instead of throwing exceptions
 // TODO: try-catch statement
 // TODO: Array data-type
 // TODO: for-loop with range operator

--- a/src/main/java/org/senthilvsh/saffron/ast/FunctionDefinition.java
+++ b/src/main/java/org/senthilvsh/saffron/ast/FunctionDefinition.java
@@ -49,6 +49,10 @@ public class FunctionDefinition extends Statement {
     }
 
     public String getSignature() {
-        return name + "_" + arguments.stream().map(a -> a.getType().getName().toLowerCase()).collect(Collectors.joining("_"));
+        String signature = name;
+        if (arguments != null && !arguments.isEmpty()) {
+            signature += "_" + arguments.stream().map(a -> a.getType().getName().toLowerCase()).collect(Collectors.joining("_"));
+        }
+        return signature;
     }
 }

--- a/src/main/java/org/senthilvsh/saffron/common/FrameStack.java
+++ b/src/main/java/org/senthilvsh/saffron/common/FrameStack.java
@@ -11,4 +11,13 @@ public class FrameStack extends Stack<Frame> {
         }
         push(newFrame);
     }
+
+    public void newBlockScope() {
+        Frame frame = peek();
+        Frame newFrame = new Frame();
+        for (Variable v : frame.values()) {
+            newFrame.put(v.getName(), new Variable(v.getName(), v.getType(), v.getValue(), true));
+        }
+        push(newFrame);
+    }
 }

--- a/src/main/java/org/senthilvsh/saffron/validate/Validator.java
+++ b/src/main/java/org/senthilvsh/saffron/validate/Validator.java
@@ -62,9 +62,13 @@ public class Validator {
                 throw new ValidationError("The condition of an 'if' statement must be a boolean expression",
                         condition.getPosition(), condition.getLength());
             }
+            stack.newBlockScope();
             validate(cs.getTrueClause());
+            stack.pop();
             if (cs.getFalseClause() != null) {
+                stack.newBlockScope();
                 validate(cs.getFalseClause());
+                stack.pop();
             }
         } else if (statement instanceof WhileLoop wl) {
             Expression condition = wl.getCondition();
@@ -73,7 +77,9 @@ public class Validator {
                 throw new ValidationError("The condition of a 'while' loop must be a boolean expression",
                         condition.getPosition(), condition.getLength());
             }
+            stack.newBlockScope();
             validate(wl.getBody());
+            stack.pop();
         } else if (statement instanceof VariableDeclaration vds) {
             String name = vds.getName();
             Type variableType = Type.of(vds.getType());


### PR DESCRIPTION
Block statements like `if-else` and `while`, introduce a new scope. This is slightly different from function scopes.

Function scopes inherit variables from parent scope, but can shadow them by declaring new variables with the same name.

In a block scope, a variable from the outer scope cannot be shadowed. Trying to declare a variable with the same name from the parent scope will throw an error. But like functions, all variables that are exclusively declared inside, go out-of-scope and are unavailable outside.